### PR TITLE
Added setting for JS minify exclude

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "name": "siteimprove/magento2",
     "description": "Bridges the gap between Magento and the Siteimprove Intelligence Platform",
+    "version": "0.1.1",
     "type": "magento2-module",
     "license": "proprietary",
     "authors": [

--- a/src/etc/config.xml
+++ b/src/etc/config.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Store:etc/config.xsd">
+    <default>
+        <dev>
+            <js>
+                <minify_exclude>
+                    https://cdn.siteimprove.net/cms/overlay
+                </minify_exclude>
+            </js>
+        </dev>
+    </default>
+</config>

--- a/src/etc/module.xml
+++ b/src/etc/module.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Siteimprove_Magento" setup_version="0.1.0">
+    <module name="Siteimprove_Magento" setup_version="0.1.1">
         <sequence>
             <module name="Magento_Cms"/>
             <module name="Magento_Catalog"/>


### PR DESCRIPTION
When in production mode with JS minification enabled, Magento will automatically attempt to fetch the minified version of overlay.js, meaning this URL: https://cdn.siteimprove.net/cms/overlay.min.js 
This URL does not exist, why the overlay cannot be loaded. This commit excludes overlay.js from automatic minification, enabling Magento to fetch the correct file.